### PR TITLE
Add the temporary file manager context.

### DIFF
--- a/productionsystem/utils.py
+++ b/productionsystem/utils.py
@@ -1,7 +1,47 @@
 """Package utility module."""
 import os
+import shutil
+from tempfile import NamedTemporaryFile, mkdtemp
 
 
 def expand_path(path):
     """Expand filesystem path."""
     return os.path.abspath(os.path.realpath(os.path.expandvars(os.path.expanduser(path))))
+
+def igroup(sequence, nentries):
+    """
+    Split a sequence into groups.
+
+    Args:
+        sequence (Sequence): The sequence to be split
+        nentries (int): The number of entries per group
+    """
+    for i in xrange(0, len(sequence), nentries):
+        yield sequence[i:i + nentries]
+
+# This can derive from ExitStack in Python3
+class TemporyFileManagerContext(object):
+    def __init__(self):
+        self._files = []
+        self._dirs = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        for file_ in self._files:
+            file_.close()
+        for dir_ in self._dirs:
+            shutil.rmtree(dir_, ignore_errors=True)
+        self._files = []
+        self._dirs = []
+
+    def new_file(self):
+        file_ = NamedTemporaryFile()
+        self._files.append(file_)
+        return file_
+
+    def new_dir(self):
+        dir_ = mkdtemp()
+        self._dirs.append(dir_)
+        return dir_


### PR DESCRIPTION
This will allow subpackage code to create temporary files/dirs other than the runscript as will and the framework will take care of cleaning them up.

Note that this patch also contains a fix to automatically determins the parametricjobs.num_jobs ( fixes https://github.com/alexanderrichards/ProductionSystem/issues/11 ) attribute from the DIRAC created id list. It is therefore no longer a required parameter. Also fixes a typo in the num_other hybrid property.