### PR TITLE
Config fix

### DIFF
--- a/scripts/dirac-daemon.py
+++ b/scripts/dirac-daemon.py
@@ -168,8 +168,11 @@ if __name__ == '__main__':
     config_instance = config.ConfigSystem.setup(config_path)
     if config_path is not None:
         arg_dict = vars(args)
+        # Lay the config params on top of default parser ones
         arg_dict.update(config_instance.get_section("dirac"))
-        args = parser.parse_args(namespace=argparse.Namespace(**arg_dict))
+        # Now parse again with the current namespace to lay non-default parsed params on top
+        args = subparser.choices[arg_dict['subcommand']] \
+                        .parse_args(sys.argv[2:], namespace=argparse.Namespace(**arg_dict))
 
     # Logging setup
     ###########################################################################

--- a/scripts/monitoring-daemon.py
+++ b/scripts/monitoring-daemon.py
@@ -161,8 +161,23 @@ if __name__ == '__main__':
     config_instance = config.ConfigSystem.setup(config_path)
     if config_path is not None:
         arg_dict = vars(args)
+        # Lay the config params on top of default parser ones
         arg_dict.update(config_instance.get_section("monitoring"))
-        args = parser.parse_args(namespace=argparse.Namespace(**arg_dict))
+        # Now parse again with the current namespace to lay non-default parsed params on top
+        # args = parser.parse_args(namespace=argparse.Namespace(**arg_dict))
+
+        # Note this doesn't work in 2.7.13 but does in 2.7.5
+        # change was made to pass a blank namespace to the subparsers to pick up any
+        # modified defaults. This breaks the logic of our code. Will have to use the subparser
+        # directly and cut out the subcommand from the args to parse.
+
+#        # can do start_parser.parse_args(sys.argv[2:], namespace=...)
+#        # but is this always ok to use start_parser?
+#        args = locals().get('%s_parser' % arg_dict['subcommand'], start_parser)\
+#                       .parse_args(sys.argv[2:], namespace=argparse.Namespace(**arg_dict))
+#        # better
+        args = subparser.choices[arg_dict['subcommand']]\
+                        .parse_args(sys.argv[2:], namespace=argparse.Namespace(**arg_dict))
 
     # Logging setup
     ###########################################################################

--- a/scripts/monitoring-daemon.py
+++ b/scripts/monitoring-daemon.py
@@ -163,6 +163,7 @@ if __name__ == '__main__':
         arg_dict = vars(args)
         # Lay the config params on top of default parser ones
         arg_dict.update(config_instance.get_section("monitoring"))
+
         # Now parse again with the current namespace to lay non-default parsed params on top
         # args = parser.parse_args(namespace=argparse.Namespace(**arg_dict))
 
@@ -170,12 +171,6 @@ if __name__ == '__main__':
         # change was made to pass a blank namespace to the subparsers to pick up any
         # modified defaults. This breaks the logic of our code. Will have to use the subparser
         # directly and cut out the subcommand from the args to parse.
-
-#        # can do start_parser.parse_args(sys.argv[2:], namespace=...)
-#        # but is this always ok to use start_parser?
-#        args = locals().get('%s_parser' % arg_dict['subcommand'], start_parser)\
-#                       .parse_args(sys.argv[2:], namespace=argparse.Namespace(**arg_dict))
-#        # better
         args = subparser.choices[arg_dict['subcommand']]\
                         .parse_args(sys.argv[2:], namespace=argparse.Namespace(**arg_dict))
 

--- a/scripts/webapp-daemon.py
+++ b/scripts/webapp-daemon.py
@@ -177,8 +177,11 @@ if __name__ == '__main__':
     config_instance = config.ConfigSystem.setup(config_path)
     if config_path is not None:
         arg_dict = vars(args)
+        # Lay the config params on top of default parser ones
         arg_dict.update(config_instance.get_section("webapp"))
-        args = parser.parse_args(namespace=argparse.Namespace(**arg_dict))
+        # Now parse again with the current namespace to lay non-default parsed params on top
+        args = subparser.choices[arg_dict['subcommand']] \
+                        .parse_args(sys.argv[2:], namespace=argparse.Namespace(**arg_dict))
 
     # Logging setup
     ###########################################################################


### PR DESCRIPTION
Used to do final step in config setup of overlaying command line args on top of config file ones as below:
```python
args = parser.parse_args(namespace=argparse.Namespace(**arg_dict))
```
---

**However:**
This doesn't work in 2.7.13 but does in 2.7.5. A change was made to pass a blank namespace to the subparsers,  in order to pick up any modified defaults. This breaks the logic of our code. Will have to use the subparser directly and cut out the subcommand from the args to parse as below:

```python
args = subparser.choices[arg_dict['subcommand']]
                .parse_args(sys.argv[2:], namespace=argparse.Namespace(**arg_dict))
```