### PR TITLE
Fix netref cache for change in rpyc dependence.

### DIFF
--- a/productionsystem/monitoring/diracrpc/DiracRPCClient.py
+++ b/productionsystem/monitoring/diracrpc/DiracRPCClient.py
@@ -17,14 +17,13 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 # which causes an not found exception server side. This tidy's up server side log since we know
 # netref<class='__builtin__.dict'> behaves as a dict
 # NOTE can't use dict or list as py2 compatibility layer rebinds these so use {}.__class__ etc.
-netref_dict = rpyc.core.netref.builtin_classes_cache[({}.__class__.__name__,
-                                                      {}.__class__.__module__)]
+netref_cache = rpyc.core.netref.builtin_classes_cache
+netref_dict = netref_cache.get('builtins.dict', netref_cache[('dict', {}.__class__.__module__)])
 copy._deepcopy_dispatch[netref_dict] = copy._deepcopy_dict
 # Add the other basic collection types
-netref_list = rpyc.core.netref.builtin_classes_cache[([].__class__.__name__,
-                                                      [].__class__.__module__)]
+netref_list = netref_cache.get('builtins.list', netref_cache[('list', [].__class__.__module__)])
 copy._deepcopy_dispatch[netref_list] = copy._deepcopy_list
-netref_tuple = rpyc.core.netref.builtin_classes_cache[(tuple.__name__, tuple.__module__)]
+netref_tuple = netref_cache.get('builtins.tuple', netref_cache[('tuple', tuple.__module__)])
 copy._deepcopy_dispatch[netref_tuple] = copy._deepcopy_tuple
 
 

--- a/productionsystem/monitoring/diracrpc/DiracRPCClient.py
+++ b/productionsystem/monitoring/diracrpc/DiracRPCClient.py
@@ -19,15 +19,24 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 # netref<class='__builtin__.dict'> behaves as a dict
 # NOTE can't use dict or list as py2 compatibility layer rebinds these so use {}.__class__ etc.
 netref_cache = rpyc.core.netref.builtin_classes_cache
-netref_dict = netref_cache.get('builtins.dict', netref_cache[(native_str('dict'),
-                                                              {}.__class__.__module__)])
+
+try:
+    netref_dict = netref_cache['builtins.dict']
+except KeyError:
+    netref_dict = netref_cache[(native_str('dict'), {}.__class__.__module__)]
 copy._deepcopy_dispatch[netref_dict] = copy._deepcopy_dict
+
 # Add the other basic collection types
-netref_list = netref_cache.get('builtins.list', netref_cache[(native_str('list'),
-                                                              [].__class__.__module__)])
+try:
+    netref_list = netref_cache['builtins.list']
+except KeyError:
+    netref_list = netref_cache[(native_str('list'), [].__class__.__module__)]
 copy._deepcopy_dispatch[netref_list] = copy._deepcopy_list
-netref_tuple = netref_cache.get('builtins.tuple', netref_cache[(native_str('tuple'),
-                                                                tuple.__module__)])
+
+try:
+    netref_tuple = netref_cache['builtins.tuple']
+except KeyError:
+    netref_tuple = netref_cache[(native_str('tuple'), tuple.__module__)]
 copy._deepcopy_dispatch[netref_tuple] = copy._deepcopy_tuple
 
 

--- a/productionsystem/monitoring/diracrpc/DiracRPCClient.py
+++ b/productionsystem/monitoring/diracrpc/DiracRPCClient.py
@@ -19,24 +19,14 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 # netref<class='__builtin__.dict'> behaves as a dict
 # NOTE can't use dict or list as py2 compatibility layer rebinds these so use {}.__class__ etc.
 netref_cache = rpyc.core.netref.builtin_classes_cache
-
-try:
-    netref_dict = netref_cache['builtins.dict']
-except KeyError:
-    netref_dict = netref_cache[(native_str('dict'), {}.__class__.__module__)]
+netref_dict = netref_cache[native_str('.'.join(({}.__class__.__module__, 'dict')))]
 copy._deepcopy_dispatch[netref_dict] = copy._deepcopy_dict
 
 # Add the other basic collection types
-try:
-    netref_list = netref_cache['builtins.list']
-except KeyError:
-    netref_list = netref_cache[(native_str('list'), [].__class__.__module__)]
+netref_list = netref_cache[native_str('.'.join(([].__class__.__module__, 'list')))]
 copy._deepcopy_dispatch[netref_list] = copy._deepcopy_list
 
-try:
-    netref_tuple = netref_cache['builtins.tuple']
-except KeyError:
-    netref_tuple = netref_cache[(native_str('tuple'), tuple.__module__)]
+netref_tuple = netref_cache[native_str('.'.join((tuple.__module__, 'tuple')))]
 copy._deepcopy_dispatch[netref_tuple] = copy._deepcopy_tuple
 
 

--- a/productionsystem/monitoring/diracrpc/DiracRPCClient.py
+++ b/productionsystem/monitoring/diracrpc/DiracRPCClient.py
@@ -3,6 +3,7 @@
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 from builtins import *  # pylint: disable=wildcard-import, unused-wildcard-import, redefined-builtin
+from future.utils import native_str
 
 import logging
 from contextlib import contextmanager
@@ -18,12 +19,15 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 # netref<class='__builtin__.dict'> behaves as a dict
 # NOTE can't use dict or list as py2 compatibility layer rebinds these so use {}.__class__ etc.
 netref_cache = rpyc.core.netref.builtin_classes_cache
-netref_dict = netref_cache.get('builtins.dict', netref_cache[('dict', {}.__class__.__module__)])
+netref_dict = netref_cache.get('builtins.dict', netref_cache[(native_str('dict'),
+                                                              {}.__class__.__module__)])
 copy._deepcopy_dispatch[netref_dict] = copy._deepcopy_dict
 # Add the other basic collection types
-netref_list = netref_cache.get('builtins.list', netref_cache[('list', [].__class__.__module__)])
+netref_list = netref_cache.get('builtins.list', netref_cache[(native_str('list'),
+                                                              [].__class__.__module__)])
 copy._deepcopy_dispatch[netref_list] = copy._deepcopy_list
-netref_tuple = netref_cache.get('builtins.tuple', netref_cache[('tuple', tuple.__module__)])
+netref_tuple = netref_cache.get('builtins.tuple', netref_cache[(native_str('tuple'),
+                                                                tuple.__module__)])
 copy._deepcopy_dispatch[netref_tuple] = copy._deepcopy_tuple
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
                       'SQLAlchemy',
                       'pymysql',
 #                      'mysql-python',
-                      'rpyc',
+                      'rpyc>=4.1.0',
                       'suds;python_version<"3"',
                       'suds-py3;python_version>"3"',
                       'gitpython',


### PR DESCRIPTION
This fix is necessary as `rpyc` have changed the format of their `netref.builtin_classes_cache` keys. This patch provides full backwards compatibility. This patch fixes https://github.com/alexanderrichards/ProductionSystem/issues/49