### PR TITLE
Make parameters to SQLAlchemy "native".

### DIFF
--- a/productionsystem/sql/models/DiracJobs.py
+++ b/productionsystem/sql/models/DiracJobs.py
@@ -7,6 +7,7 @@ from builtins import *  # pylint: disable=wildcard-import, unused-wildcard-impor
 import logging
 import json
 
+from future.utils import native
 import cherrypy
 from sqlalchemy import Column, TEXT, Integer, Enum, ForeignKey, ForeignKeyConstraint
 from sqlalchemy.orm import relationship
@@ -42,7 +43,7 @@ class DiracJobs(SQLTableBase):
         """Get dirac jobs."""
         if diracjob_id is not None:
             try:
-                diracjob_id = int(diracjob_id)
+                diracjob_id = native(int(diracjob_id))
             except ValueError:
                 cls.logger.error("Dirac job id: %r should be of type int "
                                  "(or convertable to int)", diracjob_id)
@@ -50,7 +51,7 @@ class DiracJobs(SQLTableBase):
 
         if parametricjob_id is not None:
             try:
-                parametricjob_id = int(parametricjob_id)
+                parametricjob_id = native(int(parametricjob_id))
             except ValueError:
                 cls.logger.error("Parametric job id: %r should be of type int "
                                  "(or convertable to int)", parametricjob_id)
@@ -58,7 +59,7 @@ class DiracJobs(SQLTableBase):
 
         if request_id is not None:
             try:
-                request_id = int(request_id)
+                request_id = native(int(request_id))
             except ValueError:
                 cls.logger.error("Request id: %r should be of type int "
                                  "(or convertable to int)", request_id)
@@ -66,7 +67,7 @@ class DiracJobs(SQLTableBase):
 
         if user_id is not None:
             try:
-                user_id = int(user_id)
+                user_id = native(int(user_id))
             except ValueError:
                 cls.logger.error("User id: %r should be of type int "
                                  "(or convertable to int)", user_id)

--- a/productionsystem/sql/models/ParametricJobs.py
+++ b/productionsystem/sql/models/ParametricJobs.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 from tempfile import NamedTemporaryFile
 from operator import attrgetter
 
+from future.utils import native
 import cherrypy
 from sqlalchemy import (Column, SmallInteger, Integer, Boolean, TEXT, TIMESTAMP,
                         ForeignKey, Enum, CheckConstraint, event, inspect)
@@ -281,7 +282,7 @@ class ParametricJobs(SQLTableBase):
         """Get parametric jobs."""
         if request_id is not None:
             try:
-                request_id = int(request_id)
+                request_id = native(int(request_id))
             except ValueError:
                 cls.logger.error("Request id: %r should be of type int "
                                  "(or convertable to int)", request_id)
@@ -289,7 +290,7 @@ class ParametricJobs(SQLTableBase):
 
         if parametricjob_id is not None:
             try:
-                parametricjob_id = int(parametricjob_id)
+                parametricjob_id = native(int(parametricjob_id))
             except ValueError:
                 cls.logger.error("Parametric job id: %r should be of type int "
                                  "(or convertable to int)", parametricjob_id)
@@ -297,7 +298,7 @@ class ParametricJobs(SQLTableBase):
 
         if user_id is not None:
             try:
-                user_id = int(user_id)
+                user_id = native(int(user_id))
             except ValueError:
                 cls.logger.error("User id: %r should be of type int "
                                  "(or convertable to int)", user_id)

--- a/productionsystem/sql/models/Requests.py
+++ b/productionsystem/sql/models/Requests.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime
 from operator import attrgetter
 
+from future.utils import native
 import cherrypy
 from sqlalchemy import Column, Integer, TIMESTAMP, TEXT, ForeignKey, Enum, event, inspect
 from sqlalchemy.exc import SQLAlchemyError
@@ -120,7 +121,7 @@ class Requests(SQLTableBase):
     def delete(cls, request_id):
         """Delete a requests from the DB."""
         try:
-            request_id = int(request_id)
+            request_id = native(int(request_id))
         except ValueError:
             cls.logger.error("Request id: %r should be of type int "
                              "(or convertable to int)", request_id)
@@ -145,9 +146,9 @@ class Requests(SQLTableBase):
         if request_id is not None:
             try:
                 if isinstance(request_id, (list, tuple)):
-                    request_id = [int(i) for i in request_id]
+                    request_id = [native(int(i)) for i in request_id]
                 else:
-                    request_id = int(request_id)
+                    request_id = native(int(request_id))
             except ValueError:
                 cls.logger.error("Request id: %r should be of type int "
                                  "(or convertable to int)", request_id)
@@ -155,7 +156,7 @@ class Requests(SQLTableBase):
 
         if user_id is not None:
             try:
-                user_id = int(user_id)
+                user_id = native(int(user_id))
             except ValueError:
                 cls.logger.error("User id: %r should be of type int "
                                  "(or convertable to int)", user_id)

--- a/productionsystem/sql/models/Services.py
+++ b/productionsystem/sql/models/Services.py
@@ -7,6 +7,7 @@ from builtins import *  # pylint: disable=wildcard-import, unused-wildcard-impor
 import json
 import logging
 from datetime import datetime
+from future.utils import native, native_str
 import cherrypy
 from sqlalchemy import Column, Integer, String, TIMESTAMP, Enum
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
@@ -59,13 +60,13 @@ class Services(SQLTableBase):
 
         """
         if service_name is not None:
-            if not isinstance(service_name, str):
+            if not isinstance(service_name, (str, native_str)):
                 cls.logger.error("Service name: %r should be of type str", service_name)
                 raise TypeError
 
         if service_id is not None:
             try:
-                service_id = int(service_id)
+                service_id = native(int(service_id))
             except ValueError:
                 cls.logger.error("Service id: %r should be of type int "
                                  "(or convertable to int)", service_id)

--- a/productionsystem/sql/models/Users.py
+++ b/productionsystem/sql/models/Users.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division,
 from builtins import *  # pylint: disable=wildcard-import, unused-wildcard-import, redefined-builtin
 
 import logging
+from future.utils import native
 import cherrypy
 from distutils.util import strtobool  # pylint: disable=import-error, no-name-in-module
 from sqlalchemy import Column, Integer, TEXT, Boolean
@@ -75,7 +76,7 @@ class Users(SQLTableBase):
         """
         if user_id is not None:
             try:
-                user_id = int(user_id)
+                user_id = native(int(user_id))
             except ValueError:
                 cls.logger.error("User id: %r should be of type int "
                                  "(or convertable to int)", user_id)


### PR DESCRIPTION
This is necessary as in Python 2 SQLAlchemy query filter doesn't play nicely with the compatibility layer 'newint' etc.

	modified:   productionsystem/sql/models/DiracJobs.py
	modified:   productionsystem/sql/models/ParametricJobs.py
	modified:   productionsystem/sql/models/Requests.py
	modified:   productionsystem/sql/models/Services.py
	modified:   productionsystem/sql/models/Users.py