### PR TITLE
Fix system crash with missing dirac status

### DIFF
--- a/productionsystem/sql/models/ParametricJobs.py
+++ b/productionsystem/sql/models/ParametricJobs.py
@@ -268,7 +268,8 @@ class ParametricJobs(SQLTableBase):
                                         monitored_jobs[job.id]['Status'].upper())
                     job.status = DiracStatus.UNKNOWN
             if not isinstance(job.status, DiracStatus):
-                self.logger.error("Dirac job %r status is invalid type %r", str(job.id), type(job.status))
+                self.logger.error("Dirac job %r status is invalid type %r",
+                                  str(job.id), type(job.status))
                 job.status = DiracStatus.RUNNING
             statuses.update((job.status.local_status,))
 


### PR DESCRIPTION
Sometime Dirac jobs have empty string as their status which should be invalid. This fix catches this problem and avoids crashing the entire system. The status is just set to running so that the monitoring can try again.