### PR TITLE
Updates/fixes for the log system.

### DIFF
--- a/productionsystem/sql/models/ParametricJobs.py
+++ b/productionsystem/sql/models/ParametricJobs.py
@@ -61,7 +61,7 @@ class ParametricJobs(SQLTableBase):
     num_failed = Column(Integer, nullable=False, default=0)
     num_submitted = Column(Integer, nullable=False, default=0)
     num_running = Column(Integer, nullable=False, default=0)
-    log = Column(TEXT, nullable=True)
+    log = Column(TEXT, nullable=False, default="")
     dirac_jobs = relationship("DiracJobs", cascade="all, delete-orphan",
                               primaryjoin="and_(ParametricJobs.request_id==DiracJobs.request_id, "
                                           "ParametricJobs.id==DiracJobs.parametricjob_id)")

--- a/productionsystem/sql/models/Requests.py
+++ b/productionsystem/sql/models/Requests.py
@@ -44,7 +44,7 @@ class Requests(SQLTableBase):
     request_date = Column(TIMESTAMP, nullable=False, default=datetime.utcnow)
     status = Column(Enum(LocalStatus), nullable=False, default=LocalStatus.REQUESTED)
     timestamp = Column(TIMESTAMP, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
-    log = Column(TEXT, nullable=True)
+    log = Column(TEXT, nullable=False, default="")
     parametric_jobs = relationship("ParametricJobs", cascade="all, delete-orphan")
     requester = relationship("Users")
     logger = logging.getLogger(__name__)

--- a/productionsystem/webapp/templates/dashboard_template.html
+++ b/productionsystem/webapp/templates/dashboard_template.html
@@ -365,12 +365,18 @@ $(document).ready(function(){
       $("#context_info").prop("disabled", true);
       $("#context_info").removeClass("text-primary");
       $("#context_info").addClass("text-secondary");
+      $("#context_log").prop("disabled", true);
+      $("#context_log").removeClass("text-primary");
+      $("#context_log").addClass("text-secondary");
     }
     else{
       context_menu_header.text(`Actions for request ${request_id}`);
       $("#context_info").prop("disabled", false);
       $("#context_info").addClass("text-primary");
       $("#context_info").removeClass("text-secondary");
+      $("#context_log").prop("disabled", false);
+      $("#context_log").addClass("text-primary");
+      $("#context_log").removeClass("text-secondary");
     }
     context_menu.css({
         top: event.pageY,


### PR DESCRIPTION
 - [x] When selecting multiple requests, asking for the log doesn't make sense so disallow it as with info.
 - [x] Ensure that log property is not allowed to be null and defaults to empty string. This fixes the bug where it assumes that the default (empty) log value is `None` and thus cannot append to it with the `+=` operator